### PR TITLE
Use Model.settings.acls to get the acls

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,7 @@ module.exports = {
 
 function getAuthorizedAclMethods(Model) {
   let authorizedMethods = [];
-  let acls = Model.definition.settings.acls || [];
+  let acls = Model.settings.acls || [];
 
   acls.forEach((acl) => {
     if (acl.permission === 'ALLOW' && acl.property) {


### PR DESCRIPTION
Use `Model.settings.acls` to get the acls instead of `Model.definition.settings.acl`. `Model.definition` is an artifact created by datasource-juggler, but it wouldn't exists if you just use `loopback.createModel()`.