### PR TITLE
fix disableAllExcept for hasManyThrough relations

### DIFF
--- a/setup-remote-methods.js
+++ b/setup-remote-methods.js
@@ -172,7 +172,11 @@ module.exports = (Model, options) => {
   function getRelationMethodsByRelationName(relationName) {
     const relationMethods = [];
     const relation = Model.definition.settings.relations[relationName];
-    const methodsByRelation = methodsByRelationType[relation.type];
+    let relationType = relation.type;
+    if (relationType === 'hasMany' && relation.through !== undefined) {
+      relationType = 'hasManyThrough';
+    }
+    const methodsByRelation = methodsByRelationType[relationType];
     if (!methodsByRelation) {
       return;
     }


### PR DESCRIPTION
Hello thanks for the mixin, I like it.
Found a problem related to hasManyThrough relations and disableAllExcept feature: methods 'exists', 'link', and 'unlink" are not getting disabled.
Method names are mapped by the relation type name, however hasManyThrough is not a relation type itself, actually it's just a hasMany that specifies through property.
See https://loopback.io/doc/en/lb3/HasManyThrough-relations.html#common/models/physician.json
This PR fixes the issue.